### PR TITLE
add spec helpers to ocl tools

### DIFF
--- a/lib/ocl_tools/spec_helper.rb
+++ b/lib/ocl_tools/spec_helper.rb
@@ -1,0 +1,9 @@
+require "ocl_tools/spec_helpers/autocomplete_select"
+require "ocl_tools/spec_helpers/date_picker_select"
+require "ocl_tools/spec_helpers/wait_for_turbolinks"
+
+RSpec.configure do |config|
+  config.include OclTools::AutocompleteSelect, type: :system
+  config.include OclTools::DatePickerSelect, type: :system
+  config.include OclTools::WaitForTurbolinks, type: :system
+end

--- a/lib/ocl_tools/spec_helpers/autocomplete_select.rb
+++ b/lib/ocl_tools/spec_helpers/autocomplete_select.rb
@@ -1,0 +1,15 @@
+module OclTools
+  module AutocompleteSelect
+    def autocomplete_select(name, from:)
+      raise "Name too short to be found by autocomplete: #{name}" if name.length < 3
+
+      container = find(:label, text: from).find(:xpath, "..")
+
+      # fill in the query
+      container.find('input[data-autocomplete-target="query"]').set(name[0..3])
+
+      # select the result
+      container.find("li", text: name).click
+    end
+  end
+end

--- a/lib/ocl_tools/spec_helpers/date_picker_select.rb
+++ b/lib/ocl_tools/spec_helpers/date_picker_select.rb
@@ -1,0 +1,13 @@
+module OclTools
+  module DatePickerSelect
+    def date_picker_select(date, from:)
+      container = find(:label, text: from).find(:xpath, "../..")
+
+      container.find("input").click
+      container.find("#date-picker__change-year").click
+      find("#date-picker__year-#{date.year}").click
+      find("#date-picker__month-#{date.strftime('%b')}").click
+      find("#date-picker__day-#{date.day}").click
+    end
+  end
+end

--- a/lib/ocl_tools/spec_helpers/wait_for_turbolinks.rb
+++ b/lib/ocl_tools/spec_helpers/wait_for_turbolinks.rb
@@ -1,0 +1,8 @@
+module OclTools
+  module WaitForTurbolinks
+    # https://stackoverflow.com/a/59938460
+    def wait_for_turbolinks(timeout = nil)
+      has_no_css?(".turbolinks-progress-bar", wait: timeout.presence || 5.seconds) if has_css?(".turbolinks-progress-bar", visible: true, wait: 0.25.seconds)
+    end
+  end
+end


### PR DESCRIPTION
To use, add the line `require "ocl_tools/spec_helper"` to your spec/rails_helper.