### PR TITLE
pass options through to the search reflex

### DIFF
--- a/app/components/ocl_tools/search_component.html.erb
+++ b/app/components/ocl_tools/search_component.html.erb
@@ -1,4 +1,4 @@
-<div id="search-container" data-controller='search' data-reflex-root='#search-results' data-search-classname="<%= class_name %>">
+<div id="search-container" data-controller='search' data-reflex-root='#search-results' data-search-classname-value="<%= class_name %>" data-search-params-value="<%= stringified_search_params %>">
   <label for="search" class="sr-only">Search</label>
   <div class="mt-1 relative rounded-md shadow-sm">
     <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none" aria-hidden="true">

--- a/app/components/ocl_tools/search_component.rb
+++ b/app/components/ocl_tools/search_component.rb
@@ -2,14 +2,19 @@ module OclTools
   class SearchComponent < ViewComponent::Base
     delegate :icon, to: :helpers
 
-    attr_reader :results, :search_result_blk, :class_name
+    attr_reader :results, :search_result_blk, :class_name, :search_params
 
-    def initialize(results, status, class_name: nil, &blk)
+    def initialize(results, status, class_name: nil, search_params: {}, &blk)
       @results = results
       @status = status
       @class_name = class_name
+      @search_params = search_params
 
       yield self if blk
+    end
+
+    def stringified_search_params
+      search_params && JSON.generate(search_params)
     end
 
     def search_result(&blk)

--- a/dist/controllers/search_controller.js
+++ b/dist/controllers/search_controller.js
@@ -19,12 +19,11 @@ class _class extends _application_controller.default {
 
   perform(event) {
     event.preventDefault();
-    this.classname = this.data.get("classname");
 
-    if (this.classname) {
-      this.stimulate("SearchReflex#perform", this.queryTarget.value, this.classname);
-    } else {
+    if (isEmptyObject(this.paramsValue)) {
       this.stimulate("SearchReflex#perform", this.queryTarget.value);
+    } else {
+      this.stimulate("SearchReflex#perform", this.queryTarget.value, this.paramsValue);
     }
   }
 
@@ -33,3 +32,13 @@ class _class extends _application_controller.default {
 exports.default = _class;
 
 _defineProperty(_class, "targets", ["query", "activity", "count"]);
+
+_defineProperty(_class, "values", {
+  params: Object
+});
+
+function isEmptyObject(obj) {
+  for (const i in obj) return false;
+
+  return true;
+}

--- a/javascript/controllers/search_controller.js
+++ b/javascript/controllers/search_controller.js
@@ -2,6 +2,9 @@ import ApplicationController from "./application_controller";
 
 export default class extends ApplicationController {
   static targets = ["query", "activity", "count"];
+  static values = {
+    params: Object,
+  };
 
   beforePerform() {
     this.activityTarget.hidden = false;
@@ -11,12 +14,19 @@ export default class extends ApplicationController {
   perform(event) {
     event.preventDefault();
 
-    this.classname = this.data.get("classname")
-
-    if (this.classname) {
-      this.stimulate("SearchReflex#perform", this.queryTarget.value, this.classname);
-    } else {
+    if (isEmptyObject(this.paramsValue)) {
       this.stimulate("SearchReflex#perform", this.queryTarget.value);
+    } else {
+      this.stimulate(
+        "SearchReflex#perform",
+        this.queryTarget.value,
+        this.paramsValue
+      );
     }
   }
+}
+
+function isEmptyObject(obj) {
+  for (const i in obj) return false;
+  return true;
 }


### PR DESCRIPTION
This is so we can pass arbitrary parameters through to the search reflex. Use case is to restrict the search by district e.g.:
```ruby
class SearchReflex < ApplicationReflex
  def perform(query = '', search_params = nil)
    class_name = search_params && search_params[:class_name]
    district = search_params && search_params[:district]

    if query.empty? || district.empty? || !can_access?(district)
      @status = :start
    else
      @status = :search_complete
      @results = SearchCache.get_records(query, district: district, class_name: class_name, limit: 10)
    end
  end

  def can_access?(district)
    current_staff_member.is_admin? || current_staff_member.district.to_s == district
  end
end
```