### PR TITLE
z-20 fix layers problems

### DIFF
--- a/app/components/ocl_tools/navbar_component.html.erb
+++ b/app/components/ocl_tools/navbar_component.html.erb
@@ -1,5 +1,5 @@
   <nav data-controller='visibility-toggle' class="bg-primary-600">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <div class="relative z-20 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="flex items-center justify-between h-16">
       <div class="flex items-center">
         <div class="flex-shrink-0 w-20 text-center leading-5 text-primary-200">


### PR DESCRIPTION
both notice and navbar are at z-20. They both show up, with the notice showing above the navbar.
We can change the notice to 30 if we want to make it more clear one is on top of the other, or leave it like this.
On my side, I now have no issues with other divs containing relative and absolute  highlighted when using the login modal